### PR TITLE
Feature: Add page to search

### DIFF
--- a/lib/redtube/video.rb
+++ b/lib/redtube/video.rb
@@ -6,8 +6,8 @@ module Redtube
       find_by_query("getVideoById&video_id=#{id}").first
     end
 
-    def self.search(term)
-      find_by_query "searchVideos&search=#{term}"
+    def self.search(term, page = 1)
+      find_by_query "searchVideos&search=#{term}&page=#{page}"
     end
 
     def initialize(video)

--- a/spec/video_spec.rb
+++ b/spec/video_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 register_video "getVideoById&video_id=15485"
-register_video "searchVideos&search=lesbian"
+register_video "searchVideos&search=lesbian&page=1"
 
 describe Redtube::Video do
   describe ".find" do


### PR DESCRIPTION
Currently the search does not support pagination but the API does.

The `Video.search` method now takes an additional parameter that
passes the page through to the query.
